### PR TITLE
Overload list buckets to allow bucket name parameter. Listing buckets…

### DIFF
--- a/src/main/java/synapticloop/b2/B2ApiClient.java
+++ b/src/main/java/synapticloop/b2/B2ApiClient.java
@@ -197,6 +197,18 @@ public class B2ApiClient {
 		return new B2ListBucketsRequest(client, b2AuthorizeAccountResponse).getResponse().getBuckets();
 	}
 
+	/**
+	 * List bucket in the account
+	 *
+	 * @return the bucket
+	 *
+	 * @throws B2ApiException if something went wrong
+	 * @throws IOException if there was an error communicating with the API service
+	 */
+	public B2BucketResponse listBucket(String bucketName) throws B2ApiException, IOException {
+		return new B2ListBucketsRequest(client, b2AuthorizeAccountResponse, bucketName).getResponse().getBuckets().get(0);
+	}
+
 	/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 	 *
 	 *   FILE INFORMATION API ACTIONS

--- a/src/main/java/synapticloop/b2/request/B2ListBucketsRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2ListBucketsRequest.java
@@ -50,6 +50,13 @@ public class B2ListBucketsRequest extends BaseB2Request {
 		this.addProperty(B2RequestProperties.KEY_ACCOUNT_ID, b2AuthorizeAccountResponse.getAccountId());
 	}
 
+	public B2ListBucketsRequest(CloseableHttpClient client, B2AuthorizeAccountResponse b2AuthorizeAccountResponse, String bucketName) {
+		super(client, b2AuthorizeAccountResponse, b2AuthorizeAccountResponse.getApiUrl() + B2_LIST_BUCKETS);
+
+		this.addProperty(B2RequestProperties.KEY_ACCOUNT_ID, b2AuthorizeAccountResponse.getAccountId());
+		this.addProperty(B2RequestProperties.KEY_BUCKET_NAME, bucketName);
+	}
+
 	/**
 	 * Return the list buckets response 
 	 * 


### PR DESCRIPTION
… will always return all buckets, unless you ask for just one by specifying bucketName or bucketId. If you ask for all buckets and your application key is restricted to one bucket, the call is unauthorized.