### PR TITLE
Switch requests to use GET method when possible.

### DIFF
--- a/src/main/java/synapticloop/b2/request/B2GetFileInfoRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2GetFileInfoRequest.java
@@ -52,7 +52,7 @@ public class B2GetFileInfoRequest extends BaseB2Request {
 	public B2GetFileInfoRequest(CloseableHttpClient client, B2AuthorizeAccountResponse b2AuthorizeAccountResponse, String fileId) {
 		super(client, b2AuthorizeAccountResponse, b2AuthorizeAccountResponse.getApiUrl() + B2_GET_FILE_INFO);
 
-		this.addProperty(B2RequestProperties.KEY_FILE_ID, fileId);
+		this.addParameter(B2RequestProperties.KEY_FILE_ID, fileId);
 	}
 
 	/**
@@ -64,6 +64,6 @@ public class B2GetFileInfoRequest extends BaseB2Request {
 	 * @throws IOException if there was an error communicating with the API service
 	 */
 	public B2FileResponse getResponse() throws B2ApiException, IOException {
-		return new B2FileResponse(EntityUtils.toString(executePost().getEntity()));
+		return new B2FileResponse(EntityUtils.toString(executeGet().getEntity()));
 	}
 }

--- a/src/main/java/synapticloop/b2/request/B2ListFileNamesRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2ListFileNamesRequest.java
@@ -84,19 +84,19 @@ public class B2ListFileNamesRequest extends BaseB2Request {
     public B2ListFileNamesRequest(CloseableHttpClient client, B2AuthorizeAccountResponse b2AuthorizeAccountResponse, String bucketId, String startFileName, Integer maxFileCount, String prefix, String delimiter) {
         super(client, b2AuthorizeAccountResponse, b2AuthorizeAccountResponse.getApiUrl() + B2_LIST_FILE_NAMES);
 
-        this.addProperty(B2RequestProperties.KEY_BUCKET_ID, bucketId);
+        this.addParameter(B2RequestProperties.KEY_BUCKET_ID, bucketId);
 
         if(null != startFileName) {
-            this.addProperty(B2RequestProperties.KEY_START_FILE_NAME, startFileName);
+            this.addParameter(B2RequestProperties.KEY_START_FILE_NAME, startFileName);
         }
         if(null != prefix) {
-            this.addProperty(B2RequestProperties.KEY_PREFIX, prefix);
+            this.addParameter(B2RequestProperties.KEY_PREFIX, prefix);
         }
         if(null != delimiter) {
-            this.addProperty(B2RequestProperties.KEY_DELIMITER, delimiter);
+            this.addParameter(B2RequestProperties.KEY_DELIMITER, delimiter);
         }
 
-        this.addProperty(B2RequestProperties.KEY_MAX_FILE_COUNT, maxFileCount);
+        this.addParameter(B2RequestProperties.KEY_MAX_FILE_COUNT, String.valueOf(maxFileCount));
     }
 
     /**
@@ -107,6 +107,6 @@ public class B2ListFileNamesRequest extends BaseB2Request {
      * @throws IOException    if there was an error communicating with the API service
      */
     public B2ListFilesResponse getResponse() throws B2ApiException, IOException {
-        return new B2ListFilesResponse(EntityUtils.toString(executePost().getEntity()));
+        return new B2ListFilesResponse(EntityUtils.toString(executeGet().getEntity()));
     }
 }

--- a/src/main/java/synapticloop/b2/request/B2ListFileVersionsRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2ListFileVersionsRequest.java
@@ -92,19 +92,19 @@ public class B2ListFileVersionsRequest extends BaseB2Request {
                                      String prefix, String delimiter) {
         super(client, b2AuthorizeAccountResponse, b2AuthorizeAccountResponse.getApiUrl() + B2_LIST_FILE_VERSIONS);
 
-        this.addProperty(B2RequestProperties.KEY_BUCKET_ID, bucketId);
-        this.addProperty(B2RequestProperties.KEY_MAX_FILE_COUNT, maxFileCount);
+        this.addParameter(B2RequestProperties.KEY_BUCKET_ID, bucketId);
+        this.addParameter(B2RequestProperties.KEY_MAX_FILE_COUNT, String.valueOf(maxFileCount));
         if(null != startFileName) {
-            this.addProperty(B2RequestProperties.KEY_START_FILE_NAME, startFileName);
+            this.addParameter(B2RequestProperties.KEY_START_FILE_NAME, startFileName);
         }
         if(null != startFileId) {
-            this.addProperty(B2RequestProperties.KEY_START_FILE_ID, startFileId);
+            this.addParameter(B2RequestProperties.KEY_START_FILE_ID, startFileId);
         }
         if(null != prefix) {
-            this.addProperty(B2RequestProperties.KEY_PREFIX, prefix);
+            this.addParameter(B2RequestProperties.KEY_PREFIX, prefix);
         }
         if(null != delimiter) {
-            this.addProperty(B2RequestProperties.KEY_DELIMITER, delimiter);
+            this.addParameter(B2RequestProperties.KEY_DELIMITER, delimiter);
         }
     }
 
@@ -116,6 +116,6 @@ public class B2ListFileVersionsRequest extends BaseB2Request {
      * @throws IOException    if there was an error communicating with the API service
      */
     public B2ListFilesResponse getResponse() throws B2ApiException, IOException {
-        return new B2ListFilesResponse(EntityUtils.toString(executePost().getEntity()));
+        return new B2ListFilesResponse(EntityUtils.toString(executeGet().getEntity()));
     }
 }

--- a/src/main/java/synapticloop/b2/request/B2ListPartsRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2ListPartsRequest.java
@@ -51,16 +51,16 @@ public class B2ListPartsRequest extends BaseB2Request {
 							  String fileId, Integer startPartNumber, Integer maxPartCount) {
 		super(client, b2AuthorizeAccountResponse, b2AuthorizeAccountResponse.getApiUrl() + B2_LIST_PARTS);
 
-		this.addProperty(B2RequestProperties.KEY_FILE_ID, fileId);
+		this.addParameter(B2RequestProperties.KEY_FILE_ID, fileId);
 		if (startPartNumber != null) {
-			this.addProperty(B2RequestProperties.KEY_START_PART_NUMBER, startPartNumber);
+			this.addParameter(B2RequestProperties.KEY_START_PART_NUMBER, String.valueOf(startPartNumber));
 		}
 		if (startPartNumber != null) {
-			this.addProperty(B2RequestProperties.KEY_MAX_PART_COUNT, maxPartCount);
+			this.addParameter(B2RequestProperties.KEY_MAX_PART_COUNT, String.valueOf(maxPartCount));
 		}
 	}
 
 	public B2ListPartsResponse getResponse() throws B2ApiException, IOException {
-		return new B2ListPartsResponse(EntityUtils.toString(executePost().getEntity()));
+		return new B2ListPartsResponse(EntityUtils.toString(executeGet().getEntity()));
 	}
 }

--- a/src/main/java/synapticloop/b2/request/B2ListUnfinishedLargeFilesRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2ListUnfinishedLargeFilesRequest.java
@@ -51,16 +51,16 @@ public class B2ListUnfinishedLargeFilesRequest extends BaseB2Request {
 											 String bucketId, String startFileId, Integer maxFileCount) {
 		super(client, b2AuthorizeAccountResponse, b2AuthorizeAccountResponse.getApiUrl() + B2_LIST_UNFINISHED_LARGE_FILES);
 
-		this.addProperty(B2RequestProperties.KEY_BUCKET_ID, bucketId);
+		this.addParameter(B2RequestProperties.KEY_BUCKET_ID, bucketId);
 		if (null != startFileId) {
-			this.addProperty(B2RequestProperties.KEY_START_FILE_ID, startFileId);
+			this.addParameter(B2RequestProperties.KEY_START_FILE_ID, startFileId);
 		}
 		if (maxFileCount != null) {
-			this.addProperty(B2RequestProperties.KEY_MAX_FILE_COUNT, maxFileCount);
+			this.addParameter(B2RequestProperties.KEY_MAX_FILE_COUNT, String.valueOf(maxFileCount));
 		}
 	}
 
 	public B2ListFilesResponse getResponse() throws B2ApiException, IOException {
-		return new B2ListFilesResponse(EntityUtils.toString(executePost().getEntity()));
+		return new B2ListFilesResponse(EntityUtils.toString(executeGet().getEntity()));
 	}
 }


### PR DESCRIPTION
> This API request is now being described as a GET request and not a POST request, as was the case in previous versions of our documentation.

  We made this update because we believe that an API call that retrieves data and does not alter state is more accurately represented as a GET request.